### PR TITLE
Remove unused variables and declarations

### DIFF
--- a/Framework/Atf.Atgi/AtgiXmlPersister.cs
+++ b/Framework/Atf.Atgi/AtgiXmlPersister.cs
@@ -30,12 +30,6 @@ namespace Sce.Atf.Atgi
         /// <returns>Root element metadata for the reader's current XML node</returns>
         protected override ChildInfo CreateRootElement(XmlReader reader, Uri rootUri)
         {
-            string fileNameForm = reader.GetAttribute("filenameform");
-            if (fileNameForm != null)
-            {
-                m_relativeFilePaths = (fileNameForm == "atgrootrelative");
-            }
-
             // ignore the ATGI version in the document, and use the loaded ATGI schema instead
             AtgiSchemaTypeLoader atgiSchemaTypeLoader = TypeLoader as AtgiSchemaTypeLoader;
             if (atgiSchemaTypeLoader != null)
@@ -153,7 +147,5 @@ namespace Sce.Atf.Atgi
         //    }
         //    return false;
         //}
-
-        private bool m_relativeFilePaths = true;
     }
 }

--- a/Framework/Atf.Collada/AnimationSampler.cs
+++ b/Framework/Atf.Collada/AnimationSampler.cs
@@ -120,7 +120,9 @@ namespace Sce.Atf.Collada
                 else if (semantic == "IN_TANGENT")
                     m_inTangent = source;
                 else if (semantic == "OUT_TANGENT")
-                    m_outTangent = source;
+                {
+                    // unused
+                }
                 else if (semantic == "INTERPOLATION")
                     m_interpolation = source;
             }
@@ -130,6 +132,5 @@ namespace Sce.Atf.Collada
         private Source m_inTangent;
         private Source m_interpolation;
         private Source m_output;
-        private Source m_outTangent;
     }
 }

--- a/Framework/Atf.Collada/Effect.cs
+++ b/Framework/Atf.Collada/Effect.cs
@@ -191,11 +191,11 @@ namespace Sce.Atf.Collada
             ChildInfo diffuse = shaderType.GetChildInfo("diffuse");
             ChildInfo specular = shaderType.GetChildInfo("specular");
             ChildInfo shininess = shaderType.GetChildInfo("shininess");
-            ChildInfo reflective = shaderType.GetChildInfo("reflective");
-            ChildInfo reflectivity = shaderType.GetChildInfo("reflectivity");
-            ChildInfo transparent = shaderType.GetChildInfo("transparent");
+            shaderType.GetChildInfo("reflective");
+            shaderType.GetChildInfo("reflectivity");
+            shaderType.GetChildInfo("transparent");
             ChildInfo transparency = shaderType.GetChildInfo("transparency");
-            ChildInfo indexOfRefraction = shaderType.GetChildInfo("index_of_refrac");
+            shaderType.GetChildInfo("index_of_refrac");
 
 
             if (emission != null)

--- a/Framework/Atf.Core/SearchAndReplace/LinqQueryPredicate.cs
+++ b/Framework/Atf.Core/SearchAndReplace/LinqQueryPredicate.cs
@@ -509,8 +509,8 @@ namespace Sce.Atf
             /// <param name="pattern2">High-value in "between" numerical pattern match</param>
             public NumberReplaceQueryPattern(double pattern1, double pattern2)
             {
-                m_pattern1 = pattern1;
-                m_pattern2 = pattern2;
+                //m_pattern1 = pattern1;
+                //m_pattern2 = pattern2;
             }
 
             #region IReplacingQueryPattern
@@ -539,8 +539,8 @@ namespace Sce.Atf
             }
             #endregion
 
-            double m_pattern1;
-            double m_pattern2;
+            //double m_pattern1;
+            ///double m_pattern2;
         }
 
         /// <summary>

--- a/Framework/Atf.Gui.OpenGL/CanvasControl3D.cs
+++ b/Framework/Atf.Gui.OpenGL/CanvasControl3D.cs
@@ -165,7 +165,7 @@ namespace Sce.Atf.Rendering.OpenGL
         protected override void OnKeyDown(KeyEventArgs e)
         {
             base.OnKeyDown(e);
-            bool handled = m_cameraController.KeyDown(this, e);
+            m_cameraController.KeyDown(this, e);
         }
 
         /// <summary>
@@ -316,7 +316,6 @@ namespace Sce.Atf.Rendering.OpenGL
         private int m_dragThreshold = 3;
         private int m_pickTolerance = 3;
         private bool m_isPicking;
-        private Matrix4F m_axisSystem = new Matrix4F();
 
         private readonly Camera m_camera;  // only camera object.
         private CameraController m_cameraController;

--- a/Framework/Atf.Gui.OpenGL/DevilImageLoader.cs
+++ b/Framework/Atf.Gui.OpenGL/DevilImageLoader.cs
@@ -105,7 +105,7 @@ namespace Sce.Atf.Rendering
                 CheckError();
 
                 // Load from the memory stream in to DevIl's internal unmanaged memory.
-                byte[] readBytes = LoadFromStream(imageStream);
+                LoadFromStream(imageStream);
 
                 // Determine the target file format. OpenGl supports DXT1, DXT3, and DXT5, so don't convert those.
                 // Get those pixels out of DevIl and into a managed array of bytes.

--- a/Framework/Atf.Gui.OpenGL/VboManager.cs
+++ b/Framework/Atf.Gui.OpenGL/VboManager.cs
@@ -36,7 +36,6 @@ namespace Sce.Atf.Rendering.OpenGL
             {
                 Gl.glGenBuffersARB(1, out name);
                 Gl.glBindBufferARB(Gl.GL_ARRAY_BUFFER_ARB, name);
-                int intLength = data.Length * 4;
                 Gl.glBufferDataARB(Gl.GL_ARRAY_BUFFER_ARB, new IntPtr(data.Length * 4),
                     data, Gl.GL_STATIC_DRAW_ARB);
 

--- a/Framework/Atf.Gui.WinForms/Applications/Listers/ListViewAdapter.cs
+++ b/Framework/Atf.Gui.WinForms/Applications/Listers/ListViewAdapter.cs
@@ -784,7 +784,6 @@ namespace Sce.Atf.Applications
                 IntPtr newColumn = new IntPtr(e.Column);
                 IntPtr prevColumn = new IntPtr(m_column);
                 User32.HDITEM hdItem;
-                IntPtr rtn;
 
                 if (m_column == e.Column)
                     m_direction = -m_direction;
@@ -793,15 +792,15 @@ namespace Sce.Atf.Applications
                     // Clear icon from the previous column.
                     hdItem = new User32.HDITEM();
                     hdItem.mask = User32.HDI_FORMAT;
-                    rtn = User32.SendMessageITEM(hHeader, User32.HDM_GETITEM, prevColumn, ref hdItem);
+                    User32.SendMessageITEM(hHeader, User32.HDM_GETITEM, prevColumn, ref hdItem);
                     hdItem.fmt &= ~User32.HDF_SORTDOWN & ~User32.HDF_SORTUP;
-                    rtn = User32.SendMessageITEM(hHeader, User32.HDM_SETITEM, prevColumn, ref hdItem);
+                    User32.SendMessageITEM(hHeader, User32.HDM_SETITEM, prevColumn, ref hdItem);
                 }
 
                 // Set icon on the new column.
                 hdItem = new User32.HDITEM();
                 hdItem.mask = User32.HDI_FORMAT;
-                rtn = User32.SendMessageITEM(hHeader, User32.HDM_GETITEM, newColumn, ref hdItem);
+                User32.SendMessageITEM(hHeader, User32.HDM_GETITEM, newColumn, ref hdItem);
                 if (m_direction == 1)
                 {
                     hdItem.fmt &= ~User32.HDF_SORTDOWN;
@@ -812,7 +811,7 @@ namespace Sce.Atf.Applications
                     hdItem.fmt &= ~User32.HDF_SORTUP;
                     hdItem.fmt |= User32.HDF_SORTDOWN;
                 }
-                rtn = User32.SendMessageITEM(hHeader, User32.HDM_SETITEM, newColumn, ref hdItem);
+                User32.SendMessageITEM(hHeader, User32.HDM_SETITEM, newColumn, ref hdItem);
               
 
                 m_column = e.Column;

--- a/Framework/Atf.Gui.WinForms/Applications/Listers/ResourceLister.cs
+++ b/Framework/Atf.Gui.WinForms/Applications/Listers/ResourceLister.cs
@@ -54,7 +54,6 @@ namespace Sce.Atf.Applications
             m_treeControlAdapter.TreeView = m_treeContext;
 
             m_listContext = new ListViewContext();
-            m_listSelectionContext = m_listContext.As<ISelectionContext>();
             m_listViewAdapter.ListView = m_listContext;
 
             m_treeControlAdapter.Refresh(rootFolder);
@@ -753,7 +752,6 @@ namespace Sce.Atf.Applications
         private TreeControl m_treeControl;
         
         private ListViewContext m_listContext;
-        private ISelectionContext m_listSelectionContext;
         private ListView m_listView;
         private ListViewAdapter m_listViewAdapter;
         private ThumbnailControl m_thumbnailControl;

--- a/Framework/Atf.Gui.WinForms/Applications/NetworkTargetServices/TargetTcpSocket.cs
+++ b/Framework/Atf.Gui.WinForms/Applications/NetworkTargetServices/TargetTcpSocket.cs
@@ -91,7 +91,6 @@ namespace Sce.Atf.Applications.NetworkTargetServices
             m_curTarget = null;
             m_recieveClb = new AsyncCallback(ReceiveClb);
             m_connectClb = new AsyncCallback(ConnectClb);
-            m_callingThreadId = Thread.CurrentThread.ManagedThreadId;
             m_ConnectionInProgress = false;
             MessageSize = maximumMessageSize;
         }
@@ -428,7 +427,6 @@ namespace Sce.Atf.Applications.NetworkTargetServices
         private readonly AsyncCallback m_connectClb;   // recieve callback.        
         private readonly SynchronizationContext m_cctx;
         private volatile object m_syncSocket = new object(); // used to synchronization.
-        private int m_callingThreadId; // the id of the thread that instantiated this object.
         private int m_messageSize;
         private volatile bool m_ConnectionInProgress;
     }

--- a/Framework/Atf.Gui.WinForms/Applications/SingleInstanceService.cs
+++ b/Framework/Atf.Gui.WinForms/Applications/SingleInstanceService.cs
@@ -139,6 +139,8 @@ namespace Sce.Atf.Applications
             return lease;
         }
 
+        #pragma warning disable 0414
+
         private Mutex m_mutex; //we can't dispose of this until our app shuts down
         private string[] m_commandLine;
     }

--- a/Framework/Atf.Gui.WinForms/Applications/VersionControl/ReconcileForm.cs
+++ b/Framework/Atf.Gui.WinForms/Applications/VersionControl/ReconcileForm.cs
@@ -35,8 +35,6 @@ namespace Sce.Atf.Applications
 
         private void reconcileBtn_Click(object sender, EventArgs e)
         {
-            List<Uri> uris = new List<Uri>();
-
             // check out files that are locally modified but not opened
             for (int i = 0; i < localModifiedListBox.Items.Count; i++)
             {

--- a/Framework/Atf.Gui.WinForms/Controls/Adaptable/Graphs/Circuit/CircuitEditingContext.cs
+++ b/Framework/Atf.Gui.WinForms/Controls/Adaptable/Graphs/Circuit/CircuitEditingContext.cs
@@ -54,7 +54,7 @@ namespace Sce.Atf.Controls.Adaptable.Graphs
 
         private enum MoveElementBehavior
         {
-            MoveConstrainToCursorContainment‎, // an element is eligible to move into the new container if current cursor position is contained by the new container
+            MoveConstrainToCursorContainment, // an element is eligible to move into the new container if current cursor position is contained by the new container
             MoveConstrainToContainerBounds, // an element is eligible to move into the new container only its bound are completely contained by the new container
         }
 
@@ -1111,7 +1111,7 @@ namespace Sce.Atf.Controls.Adaptable.Graphs
             if (container.Is<Circuit>())
                 return true;
 
-            if (m_moveElementBehavior == MoveElementBehavior.MoveConstrainToCursorContainment‎)
+            if (m_moveElementBehavior == MoveElementBehavior.MoveConstrainToCursorContainment)
             {
                 // since container is the drop target, the cursor must be over the container when CanMove() is called
                 return true;
@@ -1144,7 +1144,7 @@ namespace Sce.Atf.Controls.Adaptable.Graphs
         private ICircuitContainer m_circuitContainer;
         private IViewingContext m_viewingContext;
         private XmlSchemaTypeLoader m_schemaLoader;
-        private MoveElementBehavior m_moveElementBehavior = MoveElementBehavior.MoveConstrainToCursorContainment‎;
+        private MoveElementBehavior m_moveElementBehavior = MoveElementBehavior.MoveConstrainToCursorContainment;
         private bool m_supportsNestedGroup = true;
 
     }

--- a/Framework/Atf.Gui.WinForms/Controls/Adaptable/Graphs/CircuitRenderer.cs
+++ b/Framework/Atf.Gui.WinForms/Controls/Adaptable/Graphs/CircuitRenderer.cs
@@ -285,7 +285,6 @@ namespace Sce.Atf.Controls.Adaptable.Graphs
                     BuildGraphics(type, info, g);
 
                 s_pathTransform.Translate(p.X, p.Y);
-                PointF test = info.Path.PathPoints[0];
                 info.Path.Transform(s_pathTransform);
 
                 // try to use custom brush if registered

--- a/Framework/Atf.Gui.WinForms/Controls/Adaptable/Graphs/D2dCircuitRenderer.cs
+++ b/Framework/Atf.Gui.WinForms/Controls/Adaptable/Graphs/D2dCircuitRenderer.cs
@@ -1949,7 +1949,6 @@ namespace Sce.Atf.Controls.Adaptable.Graphs
 
         private RectangleF GetPointsBounds(IEnumerable<PointF> points)
         {
-            var pts = points.ToArray();
             float minX = points.Min(p => p.X);
             float minY = points.Min(p => p.Y);
             float maxX = points.Max(p => p.X);

--- a/Framework/Atf.Gui.WinForms/Controls/Adaptable/Graphs/D2dGraphAdapter.cs
+++ b/Framework/Atf.Gui.WinForms/Controls/Adaptable/Graphs/D2dGraphAdapter.cs
@@ -35,7 +35,6 @@ namespace Sce.Atf.Controls.Adaptable.Graphs
         {            
             m_renderer = renderer;
             m_renderer.Redraw += new EventHandler(renderer_Redraw);
-            m_transformAdapter = transformAdapter;
             m_renderer.GetStyle = GetStyle;
         }
 
@@ -648,7 +647,6 @@ namespace Sce.Atf.Controls.Adaptable.Graphs
         private D2dAdaptableControl m_d2dControl;
         private D2dGraphics m_d2dGraphics;
         private readonly D2dGraphRenderer<TNode, TEdge, TEdgeRoute> m_renderer;
-        private readonly ITransformAdapter m_transformAdapter;
         private object m_hoverObject;
         private object m_hoverSubObject;
         private ISelectionPathProvider m_selectionPathProvider;

--- a/Framework/Atf.Gui.WinForms/Controls/Adaptable/Graphs/D2dStatechartRenderer.cs
+++ b/Framework/Atf.Gui.WinForms/Controls/Adaptable/Graphs/D2dStatechartRenderer.cs
@@ -282,7 +282,6 @@ namespace Sce.Atf.Controls.Adaptable.Graphs
                 StateIndicators indicators = state.Indicators;
                 if ((indicators & StateIndicators.Active) != 0)
                 {
-                    bool drawIndicator = (scaleX * CornerRadius) > 2;
                     if (radInPixel > MinRadiusInPixel)
                     {
                         D2dEllipse ellipse = new D2dEllipse();
@@ -374,7 +373,6 @@ namespace Sce.Atf.Controls.Adaptable.Graphs
             D2dEllipse innerEllipse = ellipse;
             innerEllipse.RadiusX = 4;
             innerEllipse.RadiusY = 4;
-            PointF c = ellipse.Center;
 
             g.FillEllipse(ellipse, m_theme.FillBrush);
 

--- a/Framework/Atf.Gui.WinForms/Controls/Adaptable/Graphs/D2dSubCircuitRenderer.cs
+++ b/Framework/Atf.Gui.WinForms/Controls/Adaptable/Graphs/D2dSubCircuitRenderer.cs
@@ -344,7 +344,6 @@ namespace Sce.Atf.Controls.Adaptable.Graphs
         private void DrawGroupPinNodeFakeEdge(ICircuitGroupPin<TElement> grpPin, PointF grpPinPos, bool inputSide, DiagramDrawingStyle style, D2dGraphics g)
         {
             ElementTypeInfo info = GetElementTypeInfo(grpPin.InternalElement, g);
-            D2dBrush pen = (style == DiagramDrawingStyle.Normal) ? SubGraphPinBrush : Theme.GetOutLineBrush(style);
             if (inputSide)
             {             
                 PointF op = grpPinPos;

--- a/Framework/Atf.Gui.WinForms/Controls/Adaptable/Graphs/DigraphRenderer.cs
+++ b/Framework/Atf.Gui.WinForms/Controls/Adaptable/Graphs/DigraphRenderer.cs
@@ -558,8 +558,6 @@ namespace Sce.Atf.Controls.Adaptable.Graphs
             else
             {
                 // prepare to draw arc
-                RectangleF rect = new RectangleF(c.Center.X - c.Radius, c.Center.Y - c.Radius, 2 * c.Radius, 2 * c.Radius);
-
                 double angle1 = Math.Atan2(startPoint.Y - c.Center.Y, startPoint.X - c.Center.X);
                 double angle2 = Math.Atan2(endPoint.Y - c.Center.Y, endPoint.X - c.Center.X);
                 const double twoPi = 2 * Math.PI;

--- a/Framework/Atf.Gui.WinForms/Controls/Adaptable/Graphs/GraphEdgeEditAdapter.cs
+++ b/Framework/Atf.Gui.WinForms/Controls/Adaptable/Graphs/GraphEdgeEditAdapter.cs
@@ -84,11 +84,6 @@ namespace Sce.Atf.Controls.Adaptable.Graphs
         {
             m_graph = AdaptedControl.ContextAs<IGraph<TNode, TEdge, TEdgeRoute>>();
             m_editableGraph = AdaptedControl.ContextAs<IEditableGraph<TNode, TEdge, TEdgeRoute>>();
-
-            if (m_editableGraph != null)
-            {
-                m_selectionContext = AdaptedControl.ContextCast<ISelectionContext>();
-            }
         }
 
         private void control_Paint(object sender, PaintEventArgs e)
@@ -492,7 +487,6 @@ namespace Sce.Atf.Controls.Adaptable.Graphs
 
         private IGraph<TNode, TEdge, TEdgeRoute> m_graph;
         private IEditableGraph<TNode, TEdge, TEdgeRoute> m_editableGraph;
-        private ISelectionContext m_selectionContext;
 
         private GraphHitRecord<TNode, TEdge, TEdgeRoute> m_mousePick = new GraphHitRecord<TNode, TEdge, TEdgeRoute>();
         private TEdge m_hotEdge;

--- a/Framework/Atf.Gui.WinForms/Controls/Adaptable/GridAdapter.cs
+++ b/Framework/Atf.Gui.WinForms/Controls/Adaptable/GridAdapter.cs
@@ -178,12 +178,6 @@ namespace Sce.Atf.Controls.Adaptable
             float intensity = ((float)gridColor.R + (float)gridColor.G + (float)gridColor.B) / 3;
             float shading =  (intensity < 128) ? m_gridContrast : -m_gridContrast;
             m_gridColor = ColorUtil.GetShade(gridColor, 1 + shading);
-            var d2dAdaptable = AdaptedControl as D2dAdaptableControl;
-            if (d2dAdaptable != null)
-            {
-                var gridPen = d2dAdaptable.D2dGraphics.CreateSolidBrush(m_gridColor);
-              //  d2dAdaptable.Theme.GridPen = gridPen;
-            }
             Invalidate();
         }
 
@@ -227,7 +221,6 @@ namespace Sce.Atf.Controls.Adaptable
 
                 Matrix transform = m_transformAdapter.Transform;
                 RectangleF clientRect = AdaptedControl.ClientRectangle;
-                RectangleF canvasRect = GdiUtil.InverseTransform(transform, clientRect);
                 
                 // draw horizontal lines
                // ChartUtil.DrawHorizontalGrid(transform, canvasRect, m_verticalGridSpacing, d2dControl.Theme.GridPen, d2dControl.D2dGraphics);

--- a/Framework/Atf.Gui.WinForms/Controls/CurveEditing/CurveCanvas.cs
+++ b/Framework/Atf.Gui.WinForms/Controls/CurveEditing/CurveCanvas.cs
@@ -1490,7 +1490,6 @@ namespace Sce.Atf.Controls.CurveEditing
         {
             float dx = CurrentPoint.X - ClickPoint.X;
             float dy = CurrentPoint.Y - ClickPoint.Y;
-            bool hasSelection = m_selection.Count > 0;
             List<IControlPoint> points = new List<IControlPoint>();
             List<PointSelectionRegions> regions = new List<PointSelectionRegions>();
             RectangleF pickRect = RectangleF.Empty;
@@ -1702,7 +1701,6 @@ namespace Sce.Atf.Controls.CurveEditing
                 default:
                     break;
             }
-            m_lastEditAction = action;
         }
 
         
@@ -1744,7 +1742,6 @@ namespace Sce.Atf.Controls.CurveEditing
 
             ICurve hit = null;
             const float pickTol = 4;
-            RectangleF rect = RectangleF.Empty;
 
             for (int i = SelectedCurves.Length - 1; i >= 0; i--)
             {
@@ -2319,7 +2316,6 @@ namespace Sce.Atf.Controls.CurveEditing
         private ReadOnlyCollection<ICurve> m_curves = s_emptyCurves;
         private static readonly ReadOnlyCollection<ICurve> s_emptyCurves = (new List<ICurve>()).AsReadOnly();
         private readonly CurveRenderer m_renderer;
-        private MouseEditAction m_lastEditAction = MouseEditAction.None;
 
         private const float MaxAngle = 1.5706217938697f; // = 89.99 degree
         private const float MinAngle = -1.5706217938697f; // =-89.99 degree        

--- a/Framework/Atf.Gui.WinForms/Controls/CustomFileDialog.cs
+++ b/Framework/Atf.Gui.WinForms/Controls/CustomFileDialog.cs
@@ -410,7 +410,6 @@ namespace Sce.Atf
         private int m_filterIndex;
         private string m_fileName = string.Empty;
         private string[] m_fileNames = new string[0];
-        private string m_initialDir = string.Empty; //not used
         private string m_forcedInitialDir = string.Empty;
         private string m_title = string.Empty;
         private string m_defaultExt = string.Empty;

--- a/Framework/Atf.Gui.WinForms/Controls/PropertyEditing/GridView.cs
+++ b/Framework/Atf.Gui.WinForms/Controls/PropertyEditing/GridView.cs
@@ -2265,7 +2265,6 @@ namespace Sce.Atf.Controls.PropertyEditing
                     int dx = e.X - s_mouseDown.X;
                     int newWidth = s_sizingOriginalWidth + dx;
                     newWidth = Math.Max(newWidth, MinimumColumnWidth);
-                    PropertyDescriptor descriptor = s_sizingProperty.Descriptor;
                     m_gridView.SetPropertyColumnWidth(s_sizingProperty, newWidth);
                     m_gridView.Invalidate();
                 }

--- a/Framework/Atf.Gui.WinForms/Controls/PropertyEditing/WinFormsPropertyUtils.cs
+++ b/Framework/Atf.Gui.WinForms/Controls/PropertyEditing/WinFormsPropertyUtils.cs
@@ -51,7 +51,6 @@ namespace Sce.Atf.Controls.PropertyEditing
 
             public StandardValuesUIEditor(PropertyDescriptor descriptor)
             {
-                m_descriptor = descriptor;
                 m_converter = descriptor.Converter;
                 if (m_converter == null)
                     throw new ArgumentException("descriptor has no Converter");
@@ -123,8 +122,7 @@ namespace Sce.Atf.Controls.PropertyEditing
 
                 return value.ToString();
             }
-
-            private PropertyDescriptor m_descriptor;
+                
             private readonly TypeConverter m_converter;
             private IWindowsFormsEditorService m_editorService;
 

--- a/Framework/Atf.Gui.WinForms/Controls/SearchAndReplace/SearchResultsListView.cs
+++ b/Framework/Atf.Gui.WinForms/Controls/SearchAndReplace/SearchResultsListView.cs
@@ -22,8 +22,6 @@ namespace Sce.Atf.Applications
             MultiSelect = false;
             GridLines = true;
             Sorting = SortOrder.Ascending;
-
-            m_contextRegistry = contextRegistry;
         }
 
         /// <summary>
@@ -154,6 +152,5 @@ namespace Sce.Atf.Applications
         }
 
         private IQueryableResultContext m_queryResultContext;
-        private IContextRegistry m_contextRegistry;
     }
 }

--- a/Framework/Atf.Gui.WinForms/Controls/Timelines/Direct2D/D2dSnapManipulator.cs
+++ b/Framework/Atf.Gui.WinForms/Controls/Timelines/Direct2D/D2dSnapManipulator.cs
@@ -106,7 +106,6 @@ namespace Sce.Atf.Controls.Timelines.Direct2D
                     dist < m_dist)
                 {
                     m_snapToPoint = snapToPoint;
-                    m_snapToEvent = snapToEvent;
                     m_dist = dist;
                 }
             }
@@ -144,7 +143,6 @@ namespace Sce.Atf.Controls.Timelines.Direct2D
             private readonly float m_snapFromPoint;
             private float m_dist;
             private float m_snapToPoint;
-            private IEvent m_snapToEvent;
         }
 
         /// <summary>

--- a/Framework/Atf.Gui.WinForms/Controls/Timelines/Direct2D/D2dTimelineControl.cs
+++ b/Framework/Atf.Gui.WinForms/Controls/Timelines/Direct2D/D2dTimelineControl.cs
@@ -112,10 +112,10 @@ namespace Sce.Atf.Controls.Timelines.Direct2D
                 //  order of receiving picking events. For example, a custom Control that is drawn
                 //  on top of everything else and that can be clicked on should come last in this
                 //  list so that it is drawn last and is picked first.
-                D2dSelectionManipulator selectionManipulator = new D2dSelectionManipulator(this);
-                D2dMoveManipulator moveManipulator = new D2dMoveManipulator(this);
-                D2dScaleManipulator scaleManipulator = new D2dScaleManipulator(this);
-                D2dSplitManipulator splitManipulator = new D2dSplitManipulator(this);
+                new D2dSelectionManipulator(this);
+                new D2dMoveManipulator(this);
+                new D2dScaleManipulator(this);
+                new D2dSplitManipulator(this);
                 D2dSnapManipulator snapManipulator = new D2dSnapManipulator(this);
                 D2dScrubberManipulator scrubberManipulator = new D2dScrubberManipulator(this);
 

--- a/Framework/Atf.Gui.WinForms/Controls/Timelines/Gdi/TimelineControl.cs
+++ b/Framework/Atf.Gui.WinForms/Controls/Timelines/Gdi/TimelineControl.cs
@@ -100,10 +100,10 @@ namespace Sce.Atf.Controls.Timelines
                 //  order of receiving picking events. For example, a custom Control that is drawn
                 //  on top of everything else and that can be clicked on should come last in this
                 //  list so that it is drawn last and is picked first.
-                SelectionManipulator selectionManipulator = new SelectionManipulator(this);
-                MoveManipulator moveManipulator = new MoveManipulator(this);
-                ScaleManipulator scaleManipulator = new ScaleManipulator(this);
-                SplitManipulator splitManipulator = new SplitManipulator(this);
+                new SelectionManipulator(this);
+                new MoveManipulator(this);
+                new ScaleManipulator(this);
+                new SplitManipulator(this);
                 SnapManipulator snapManipulator = new SnapManipulator(this);
                 ScrubberManipulator scrubberManipulator = new ScrubberManipulator(this);
 
@@ -1428,8 +1428,6 @@ namespace Sce.Atf.Controls.Timelines
         /// <param name="e">A <see cref="T:System.Windows.Forms.MouseEventArgs"></see> that contains the event data</param>
         protected override void OnMouseWheel(MouseEventArgs e)
         {
-            // for each click, scroll horizontally by 1/2 pixel
-            int dx = e.Delta / 2;
             Invalidate();
 
             base.OnMouseWheel(e);

--- a/Framework/Atf.Gui.WinForms/Controls/Timelines/Gdi/TimelineRenderer.cs
+++ b/Framework/Atf.Gui.WinForms/Controls/Timelines/Gdi/TimelineRenderer.cs
@@ -32,7 +32,6 @@ namespace Sce.Atf.Controls.Timelines
         {
             m_font = font;
             m_gridPen = new Pen(Color.FromArgb(128, 128, 128, 128));
-            m_collapsedBrush = new SolidBrush(Color.LightGray);
         }
 
         /// <summary>
@@ -942,8 +941,6 @@ namespace Sce.Atf.Controls.Timelines
             {
                 bounds = GetGroupHandleRect(bounds, collapsed);
 
-                RectangleF groupLabelBounds = new RectangleF(bounds.X, bounds.Y, m_headerWidth, bounds.Height);
-
                 if (collapsible)
                 {
                     RectangleF expanderRect = GetExpanderRect(bounds);
@@ -1460,7 +1457,6 @@ namespace Sce.Atf.Controls.Timelines
         private readonly Pen m_gridPen;
         private bool m_disposed;
         private float m_OffsetX;
-        private Brush m_collapsedBrush;
         private float m_minimumTrackSize = 0.025f;
         private int m_expanderRectSize = 8;
         private Padding m_expanderRectMargin = new Padding(3, 3, 3, 3);

--- a/Framework/Atf.Gui.WinForms/Controls/TreeItemRenderer.cs
+++ b/Framework/Atf.Gui.WinForms/Controls/TreeItemRenderer.cs
@@ -428,7 +428,6 @@ namespace Sce.Atf.Controls
 
         private SolidBrush m_brushMatchedHighLight = new SolidBrush(Color.FromArgb(239, 203, 5));
         private SolidBrush m_brushNonMatchedBg = new SolidBrush(Color.FromArgb(230, 230, 230));
-        private SolidBrush m_brushPartialExpander = new SolidBrush(Color.FromArgb(180, 180, 180));
 
         private Color m_categoryStartColor = Color.FromArgb(0, 0, 0, 0);
         private Color m_categoryEndColor = Color.FromArgb(0, 0, 0, 0);

--- a/Framework/Atf.Gui/Applications/NetworkTargetServices/Deci4pTargetProvider.cs
+++ b/Framework/Atf.Gui/Applications/NetworkTargetServices/Deci4pTargetProvider.cs
@@ -64,7 +64,7 @@ namespace Sce.Atf.Applications.NetworkTargetServices
         /// <param name="e">Event args</param>
         void BgwDoWork(object sender, DoWorkEventArgs e)
         {
-            var bgw = sender as BackgroundWorker;
+            //var bgw = sender as BackgroundWorker;
             var result = new List<TargetInfo>();
             result.AddRange(FindTargets());
             e.Result = result;                                  

--- a/Framework/Atf.Gui/Applications/OscService.cs
+++ b/Framework/Atf.Gui/Applications/OscService.cs
@@ -519,7 +519,7 @@ namespace Sce.Atf.Applications
             }
             else
             {
-                var bundle = new OscBundle(ReceivingEndpoint, null);
+                var bundle = new OscBundle(ReceivingEndpoint);
                 for (int i = first; i < first + count; i++)
                 {
                     Tuple<string, object> tuple = addressesAndData[i];

--- a/Framework/Atf.Gui/Applications/VersionControl/SourceControlRevision.cs
+++ b/Framework/Atf.Gui/Applications/VersionControl/SourceControlRevision.cs
@@ -77,7 +77,7 @@ namespace Sce.Atf.Applications
         {
             get
             {
-                if (m_kind != SourceControlRevisionKind.Date || m_dateTime == null)
+                if (m_kind != SourceControlRevisionKind.Date)
                     throw new InvalidOperationException("This revision is not a Date");
                 return m_dateTime;
             }

--- a/Framework/Atf.Gui/Controls/Adaptable/Graphs/Circuit/ElementType.cs
+++ b/Framework/Atf.Gui/Controls/Adaptable/Graphs/Circuit/ElementType.cs
@@ -52,7 +52,7 @@ namespace Sce.Atf.Controls.Adaptable.Graphs
         {
             m_name = name;
             m_isConnector = isConnector;
-            m_size = size;
+            //m_size = size;
             m_image = image;
             m_inputPins = inputPins;
             m_outputPins = outputPins;
@@ -161,7 +161,7 @@ namespace Sce.Atf.Controls.Adaptable.Graphs
         private string m_name;
         private ICircuitPin[] m_inputPins;
         private ICircuitPin[] m_outputPins;
-        private Size m_size;
+        //private Size m_size;
         private Image m_image;
         private bool m_isConnector;
     }

--- a/Framework/Atf.Gui/Rendering/SceneGraphBuilder.cs
+++ b/Framework/Atf.Gui/Rendering/SceneGraphBuilder.cs
@@ -42,7 +42,7 @@ namespace Sce.Atf.Rendering.Dom
                 throw new InvalidOperationException("Must be an IRenderObject");
 
             m_treeView = treeView;
-            m_type = type;
+            //m_type = type;
         }
 
         /// <summary>
@@ -206,7 +206,7 @@ namespace Sce.Atf.Rendering.Dom
         }
 
         private readonly ITreeView m_treeView;
-        private Type m_type;
+        //private Type m_type;
         private static readonly object s_lock = new object();//to control access to the static members
         private static readonly HashSet<object> s_ancestors = new HashSet<object>();
     }

--- a/Samples/CircuitEditor/Circuit.cs
+++ b/Samples/CircuitEditor/Circuit.cs
@@ -21,7 +21,7 @@ namespace CircuitEditorSample
             // cache these list wrapper objects
             m_modules = new DomNodeListAdapter<Module>(DomNode, Schema.circuitType.moduleChild);
             m_connections = new DomNodeListAdapter<Connection>(DomNode, Schema.circuitType.connectionChild);
-            m_annotations = new DomNodeListAdapter<Annotation>(DomNode, Schema.circuitType.annotationChild);
+            new DomNodeListAdapter<Annotation>(DomNode, Schema.circuitType.annotationChild);
             base.OnNodeSet();
         }
 
@@ -94,6 +94,5 @@ namespace CircuitEditorSample
 
         private DomNodeListAdapter<Module> m_modules;
         private DomNodeListAdapter<Connection> m_connections;
-        private DomNodeListAdapter<Annotation> m_annotations;
     }
 }

--- a/Samples/CircuitEditor/Editor.cs
+++ b/Samples/CircuitEditor/Editor.cs
@@ -65,7 +65,6 @@ namespace CircuitEditorSample
             m_contextRegistry = contextRegistry;
             m_documentRegistry = documentRegistry;
             m_documentService = documentService;
-            m_prototypeLister = prototypeLister;
             m_layerLister = layerLister;
             
             m_schemaLoader = schemaLoader;
@@ -100,7 +99,6 @@ namespace CircuitEditorSample
         private IContextRegistry m_contextRegistry;
         private IDocumentRegistry m_documentRegistry;
         private IDocumentService m_documentService;
-        private PrototypeLister m_prototypeLister;
         private LayerLister m_layerLister;
         private SchemaLoader m_schemaLoader;
 
@@ -701,48 +699,24 @@ namespace CircuitEditorSample
             var hoverItem = e.Object;
             var hoverPart = e.Part;
 
-            string itemName= string.Empty;
-            string partName= string.Empty;
-
             if (e.SubPart.Is<GroupPin>())
             {
                 sb.Append(e.SubPart.Cast<GroupPin>().Name);
-                partName = CircuitUtil.GetDomNodeName(e.SubPart.Cast<DomNode>());
+                CircuitUtil.GetDomNodeName(e.SubPart.Cast<DomNode>());
             }
             else if (e.SubObject.Is<DomNode>())
             {
-                itemName = CircuitUtil.GetDomNodeName(e.SubObject.Cast<DomNode>());
+                CircuitUtil.GetDomNodeName(e.SubObject.Cast<DomNode>());
             }
             else if (hoverPart.Is<GroupPin>())
             {
                 sb.Append(hoverPart.Cast<GroupPin>().Name);
-                partName = CircuitUtil.GetDomNodeName(hoverPart.Cast<DomNode>());
+                CircuitUtil.GetDomNodeName(hoverPart.Cast<DomNode>());
             }
             else if (hoverItem.Is<DomNode>())
             {
-                itemName = CircuitUtil.GetDomNodeName(hoverItem.Cast<DomNode>());
+                CircuitUtil.GetDomNodeName(hoverItem.Cast<DomNode>());
             }
-           
-
-            //Trace.TraceInformation("hoverItem {0} hoverPart  {1}", itemName, partName);
-
-            //StringBuilder sb = new StringBuilder();
-            //ICustomTypeDescriptor customTypeDescriptor = Adapters.As<ICustomTypeDescriptor>(hoverItem);
-            //if (customTypeDescriptor != null)
-            //{
-            //    // Get properties interface
-            //    foreach (System.ComponentModel.PropertyDescriptor property in customTypeDescriptor.GetProperties())
-            //    {
-            //        object value = property.GetValue(hoverItem);
-            //        if (value != null)
-            //        {
-            //            sb.Append(property.Name);
-            //            sb.Append(": ");
-            //            sb.Append(value.ToString());
-            //            sb.Append("\n");
-            //        }
-            //    }
-            //}
 
             HoverBase result = null;
             if (sb.Length > 0) // remove trailing '\n'

--- a/Samples/CircuitEditor/Group.cs
+++ b/Samples/CircuitEditor/Group.cs
@@ -20,9 +20,9 @@ namespace CircuitEditorSample
         {
             m_modules = new DomNodeListAdapter<Module>(DomNode, Schema.groupType.moduleChild);
             m_connections = new DomNodeListAdapter<Connection>(DomNode, Schema.groupType.connectionChild);
-            m_annotations = new DomNodeListAdapter<Annotation>(DomNode, Schema.groupType.annotationChild);
-            m_inputs = new DomNodeListAdapter<GroupPin>(DomNode, Schema.groupType.inputChild);
-            m_outputs = new DomNodeListAdapter<GroupPin>(DomNode, Schema.groupType.outputChild);
+            new DomNodeListAdapter<Annotation>(DomNode, Schema.groupType.annotationChild);
+            new DomNodeListAdapter<GroupPin>(DomNode, Schema.groupType.inputChild);
+            new DomNodeListAdapter<GroupPin>(DomNode, Schema.groupType.outputChild);
             m_thisModule = DomNode.Cast<Module>();
 
             base.OnNodeSet();
@@ -230,8 +230,5 @@ namespace CircuitEditorSample
         private DomNodeListAdapter<Module> m_modules;
         private DomNodeListAdapter<Connection> m_connections;
         private Module m_thisModule;
-        private DomNodeListAdapter<Annotation> m_annotations;
-        private DomNodeListAdapter<GroupPin> m_inputs;
-        private DomNodeListAdapter<GroupPin> m_outputs;
     }
 }

--- a/Samples/CircuitEditor/Tests/CircuitTestCommands.cs
+++ b/Samples/CircuitEditor/Tests/CircuitTestCommands.cs
@@ -29,7 +29,6 @@ namespace CircuitEditorSample.Tests
             SchemaLoader schemaLoader)
         {
             m_commandService = commandService;
-            m_contextRegistry = contextRegistry;
             m_schemaLoader = schemaLoader;
         }
 
@@ -124,7 +123,6 @@ namespace CircuitEditorSample.Tests
         private IControlHostService m_controlHostService= null;
 
         private ICommandService m_commandService;
-        private IContextRegistry m_contextRegistry;
         private SchemaLoader m_schemaLoader;
     }
 

--- a/Samples/CodeEditor/Editor.cs
+++ b/Samples/CodeEditor/Editor.cs
@@ -54,6 +54,8 @@ namespace CodeEditor
         [Import(AllowDefault = true)]
         private SourceControlService m_sourceControlService = null;
 
+        #pragma warning disable 0414
+
         [Export(typeof(IDocumentClient))]
         private DocumentClient m_txtDocumentClient;
 

--- a/Samples/FileExplorer/FileViewer.cs
+++ b/Samples/FileExplorer/FileViewer.cs
@@ -248,6 +248,7 @@ namespace FileExplorerSample
 
             static FileListView()
             {
+                #pragma warning disable 0219
                 string dummy = Resources.FolderImage; // force initialization of image resources
             }
         }

--- a/Samples/FsmEditor/Editor.cs
+++ b/Samples/FsmEditor/Editor.cs
@@ -55,7 +55,6 @@ namespace FsmEditorSample
             m_contextRegistry = contextRegistry;
             m_documentRegistry = documentRegistry;
             m_documentService = documentService;
-            m_prototypeLister = prototypeLister;
 
             m_schemaLoader = schemaLoader;
 
@@ -71,7 +70,6 @@ namespace FsmEditorSample
         private IContextRegistry m_contextRegistry;
         private IDocumentRegistry m_documentRegistry;
         private IDocumentService m_documentService;
-        private PrototypeLister m_prototypeLister;
         private SchemaLoader m_schemaLoader;
         
         [Import(AllowDefault = true)]

--- a/Samples/FsmEditor/TransitionRouter.cs
+++ b/Samples/FsmEditor/TransitionRouter.cs
@@ -37,7 +37,6 @@ namespace FsmEditorSample
         {
             if (e.DomNode.Type == Schema.transitionType.Type)
             {
-                Transition transition = e.DomNode.As<Transition>();
                 if (e.AttributeInfo.Equivalent(Schema.transitionType.sourceAttribute))
                 {
                     m_routingInvalid = true;

--- a/Samples/SimpleDomEditor/EventListEditor.cs
+++ b/Samples/SimpleDomEditor/EventListEditor.cs
@@ -33,7 +33,6 @@ namespace SimpleDomEditorSample
             ICommandService commandService,
             IContextRegistry contextRegistry)
         {
-            m_controlHostService = controlHostService;
             m_commandService = commandService;
             m_contextRegistry = contextRegistry;
 
@@ -41,8 +40,7 @@ namespace SimpleDomEditorSample
             m_contextRegistry.ContextAdded += new EventHandler<ItemInsertedEventArgs<object>>(contextRegistry_ContextAdded);
             m_contextRegistry.ContextRemoved += new EventHandler<ItemRemovedEventArgs<object>>(contextRegistry_ContextRemoved);
         }
-
-        private IControlHostService m_controlHostService;
+            
         private ICommandService m_commandService;
         private IContextRegistry m_contextRegistry;
 

--- a/Samples/SimpleDomNoXmlEditor/Editor.cs
+++ b/Samples/SimpleDomNoXmlEditor/Editor.cs
@@ -41,14 +41,12 @@ namespace SimpleDomNoXmlEditorSample
             m_documentService = documentService;
             m_contextRegistry = contextRegistry;
             m_documentRegistry = documentRegistry;
-            m_domTypes = domTypes.GetDomTypes();
         }
 
         private IControlHostService m_controlHostService;
         private IDocumentService m_documentService;
         private IContextRegistry m_contextRegistry;
         private IDocumentRegistry m_documentRegistry;
-        private IEnumerable<DomNodeType> m_domTypes;
 
         // scripting related members
         [Import(AllowDefault = true)]

--- a/Samples/SimpleDomNoXmlEditor/EventListEditor.cs
+++ b/Samples/SimpleDomNoXmlEditor/EventListEditor.cs
@@ -33,7 +33,6 @@ namespace SimpleDomNoXmlEditorSample
             ICommandService commandService,
             IContextRegistry contextRegistry)
         {
-            m_controlHostService = controlHostService;
             m_commandService = commandService;
             m_contextRegistry = contextRegistry;
 
@@ -41,8 +40,7 @@ namespace SimpleDomNoXmlEditorSample
             m_contextRegistry.ContextAdded += new EventHandler<ItemInsertedEventArgs<object>>(contextRegistry_ContextAdded);
             m_contextRegistry.ContextRemoved += new EventHandler<ItemRemovedEventArgs<object>>(contextRegistry_ContextRemoved);
         }
-
-        private IControlHostService m_controlHostService;
+            
         private ICommandService m_commandService;
         private IContextRegistry m_contextRegistry;
 

--- a/Samples/StatechartEditor/Editor.cs
+++ b/Samples/StatechartEditor/Editor.cs
@@ -58,7 +58,6 @@ namespace StatechartEditorSample
             m_contextRegistry = contextRegistry;
             m_documentRegistry = documentRegistry;
             m_documentService = documentService;
-            m_prototypeLister = prototypeLister;
 
             m_schemaLoader = schemaLoader;
 
@@ -82,7 +81,6 @@ namespace StatechartEditorSample
         private IContextRegistry m_contextRegistry;
         private IDocumentRegistry m_documentRegistry;
         private IDocumentService m_documentService;
-        private PrototypeLister m_prototypeLister;
 
         [Import(AllowDefault = true)]
         private IStatusService m_statusService = null;

--- a/Samples/TimelineEditor/TimelineDocument.cs
+++ b/Samples/TimelineEditor/TimelineDocument.cs
@@ -195,9 +195,9 @@ namespace TimelineEditorSample
             //  order of receiving picking events. For example, a custom Control that is drawn
             //  on top of everything else and that can be clicked on should come last in this
             //  list so that it is drawn last and is picked first.
-            D2dSelectionManipulator selectionManipulator = new D2dSelectionManipulator(m_timelineControl);
-            D2dMoveManipulator moveManipulator = new D2dMoveManipulator(m_timelineControl);
-            D2dScaleManipulator scaleManipulator = new D2dScaleManipulator(m_timelineControl);
+            new D2dSelectionManipulator(m_timelineControl);
+            new D2dMoveManipulator(m_timelineControl);
+            new D2dScaleManipulator(m_timelineControl);
             m_splitManipulator = new D2dSplitManipulator(m_timelineControl);
             D2dSnapManipulator snapManipulator = new D2dSnapManipulator(m_timelineControl);
             D2dScrubberManipulator scrubberManipulator = new ScrubberManipulator(m_timelineControl);

--- a/Samples/TimelineEditor/TimelineEditor.cs
+++ b/Samples/TimelineEditor/TimelineEditor.cs
@@ -588,19 +588,19 @@ namespace TimelineEditorSample
 
         private void observable_Reloaded(object sender, EventArgs e)
         {
-            TimelineDocument doc = sender.Cast<TimelineDocument>();
+            sender.Cast<TimelineDocument>();
             InvalidateTimelineControls();
         }
 
         private void observable_ItemRemoved(object sender, ItemRemovedEventArgs<object> e)
         {
-            TimelineDocument doc = sender.Cast<TimelineDocument>();
+            sender.Cast<TimelineDocument>();
             InvalidateTimelineControls();
         }
 
         private void observable_ItemChanged(object sender, ItemChangedEventArgs<object> e)
         {
-            TimelineDocument doc = sender.Cast<TimelineDocument>();
+            sender.Cast<TimelineDocument>();
             InvalidateTimelineControls();
         }
 

--- a/Samples/UsingDirect2D/Form1.cs
+++ b/Samples/UsingDirect2D/Form1.cs
@@ -1309,8 +1309,6 @@ namespace UsingDirect2D
         private List<D2dLinearGradientBrush>
             m_linearBrushes2 = new List<D2dLinearGradientBrush>();
 
-
-        private RectangleF m_infoRect = new RectangleF(0, 0, 500, 32);
         private Clock frmclk = new Clock();
         private float m_cumulativeTime = 0;
         private int m_frameCount = 0;

--- a/Samples/UsingDirect2D/GdiCanvas.cs
+++ b/Samples/UsingDirect2D/GdiCanvas.cs
@@ -26,21 +26,6 @@ namespace UsingDirect2D
 
             // create few solid color bruhes.
             m_brush1 = new SolidBrush(Color.White);
-            m_brush2 = new SolidBrush(Color.White);
-            m_brush3 = new SolidBrush(Color.White);
-
-
-            // create linear gradient brush for painting complex state (state samples).
-            // copied from state machine editor.
-            Color stateColor1 = System.Drawing.Color.FromArgb(142, 182, 243);
-            float retain = 0.75f;
-            int stred = (int)(stateColor1.R * retain);
-            int stgreen = (int)(stateColor1.G * retain);
-            int stblue = (int)(stateColor1.B * retain);
-            Color stateColor2 = Color.FromArgb(stred, stgreen, stblue);
-            
-            //m_titlebrush = m_d2dGraphics.CreateLinearGradientBrush(gradstops);
-
 
             // create bitmap resources
             m_bmp = new Bitmap("Resources\\Level1.png");
@@ -415,8 +400,6 @@ namespace UsingDirect2D
 
         private Bitmap m_bmp;
         private SolidBrush m_brush1;
-        private SolidBrush m_brush2;
-        private SolidBrush m_brush3;
 
         private Font m_info;
 
@@ -439,11 +422,6 @@ namespace UsingDirect2D
         private List<Rectangle> m_rects
             = new List<Rectangle>();
 
-
-
-        private List<PointF> m_connectedLines
-            = new List<PointF>();
-
         private List<Line> m_lines
             = new List<Line>();
 
@@ -453,11 +431,7 @@ namespace UsingDirect2D
         private List<PointF> m_texts
             = new List<PointF>();
 
-        private List<State> m_states
-            = new List<State>();
-
         private StringFormat m_strFormat;
-        private RectangleF m_infoRect = new RectangleF(0, 0, 500, 32);
 
         private enum SampleDrawings
         {


### PR DESCRIPTION
Mono detects unused variables and private field declarations as warnings.  Because ATF has "warnings as errors" enabled, these issues appear as errors and prevent compilation.

This PR removes unused / dead code, unused variables and unused private declarations.  In scenarios where the declaration is required (e.g. in one particular Mutex case), I've added a #pragma to disable the warning instead.
