### PR TITLE
Bug Fix: Doc window close button hides window but doesn't close document

### DIFF
--- a/Framework/Atf.Gui.Wpf/Applications/ControlHostService.cs
+++ b/Framework/Atf.Gui.Wpf/Applications/ControlHostService.cs
@@ -154,6 +154,7 @@ namespace Sce.Atf.Wpf.Applications
 
             IDockContent dockContent = m_dockPanel.RegisterContent(control, def.Id, ControlGroupToDockTo(def.Group));
             dockContent.IsFocusedChanged += DockContent_IsFocusedChanged;
+            dockContent.Closing += DockContentOnClosing;
 
             ControlInfo contentInfo = new ControlInfo(def.Name, def.Description, def.Id, def.Group, def.ImageSourceKey, dockContent, client);
 
@@ -323,6 +324,13 @@ namespace Sce.Atf.Wpf.Applications
 
                 m_activeDockControl = activeControl;
             }
+        }
+
+        private void DockContentOnClosing(object sender, ContentClosedEventArgs e) {
+            DockContent dockContent = (DockContent)sender;
+
+            var controlInfo = FindControlInfo(dockContent.Content);
+            controlInfo.Client.Close(dockContent.Content, false);
         }
 
         private ControlInfo FindControlInfo(object content)


### PR DESCRIPTION
I mentioned in the forum a small bug I found in the SimpleDomEditorWpf sample.  This is the fix I found for it.

Ron indicated that he thought the capability was probably all there in the WPF project, but the best change seemed to be in the ControlHostService, instead of something in the sample project itself.

Let me know if there is a different solution I should track down.

All Unit tests pass. No new unit tests at this time.