### PR TITLE
SettingsDialog custom path fix

### DIFF
--- a/Framework/Atf.Gui.WinForms/Applications/SettingsDialog.cs
+++ b/Framework/Atf.Gui.WinForms/Applications/SettingsDialog.cs
@@ -52,10 +52,10 @@ namespace Sce.Atf.Applications
             propertiesPanel.Controls.Add(m_propertyGrid);
 
             // select an initial node so something is displayed in the PropertyGrid
-            TreeControl.Node firstNode;
+            TreeControl.Node firstNode = null;
             if (pathName != null)
                 firstNode = m_treeControlAdapter.ExpandPath(m_settingsService.GetSettingsPath(pathName));
-            else
+            if (firstNode == null) // in case pathName is not null, but ExpandPath returns null
                 firstNode = m_treeControl.ExpandToFirstLeaf();
 
             firstNode.Selected = true;

--- a/Framework/Atf.Gui.WinForms/Applications/SettingsService.cs
+++ b/Framework/Atf.Gui.WinForms/Applications/SettingsService.cs
@@ -638,22 +638,22 @@ namespace Sce.Atf.Applications
 
             // first node is the settings tree root
             Tree<object> node = m_userSettings;
-            path[0] = m_userSettings.Value;
+            path[0] = m_userSettings;
 
             // middle nodes are folders
             for (int i = 1; i < path.Length - 1; i++)
             {
                 node = GetOrCreateFolder(pathSegments[i - 1], node);
-                path[i] = node.Value;
+                path[i] = node;
             }
 
             // leaf node is user settings object
             foreach (Tree<object> leaf in node.Children)
             {
-                var info = node.Value as UserSettingsInfo;
+                UserSettingsInfo info = leaf.Value as UserSettingsInfo;
                 if (info != null && info.Name == pathSegments[pathSegments.Length - 1])
                 {
-                    path[path.Length - 1] = leaf.Value;
+                    path[path.Length - 1] = leaf;
                     break;
                 }
             }


### PR DESCRIPTION
If a custom path is provided to SettingsDialog, a crash will occur
because SettingsDialog will call the internal
SettingsService.GetSettingsPath() and expect to receive a path of Tree
objects. SettingsService.GetSettingsPath() was actually returning the
Value of each of those Tree objects.