### PR TITLE
TreeControl user re-ordering support

### DIFF
--- a/Framework/Atf.Gui.WinForms/Applications/Listers/TreeControlEditor.cs
+++ b/Framework/Atf.Gui.WinForms/Applications/Listers/TreeControlEditor.cs
@@ -166,7 +166,7 @@ namespace Sce.Atf.Applications
                 {
                     canInsert = ApplicationUtil.CanInsertBetween(
                         m_treeControlAdapter.TreeView,
-                        parent.Tag,
+                        parent != null ? parent.Tag : null,
                         before != null ? before.Tag : null,
                         e.Data);
                 }
@@ -199,7 +199,7 @@ namespace Sce.Atf.Applications
                 {
                     ApplicationUtil.InsertBetween(
                         m_treeControlAdapter.TreeView,
-                        parent.Tag,
+                        parent != null ? parent.Tag : null,
                         before != null ? before.Tag : null,
                         e.Data,
                         "Drag and Drop",

--- a/Framework/Atf.Gui.WinForms/Applications/Listers/TreeControlEditor.cs
+++ b/Framework/Atf.Gui.WinForms/Applications/Listers/TreeControlEditor.cs
@@ -156,17 +156,34 @@ namespace Sce.Atf.Applications
         /// <param name="e">Event args from the tree control's DragOver event</param>
         protected virtual void OnDragOver(DragEventArgs e)
         {
-            bool showDragBetweenCue = TreeControl.ShowDragBetweenCue;
-            TreeControl.ShowDragBetweenCue = false;
+            bool canInsert = false;
+            
+            if (TreeControl.DragBetween)
+            {
+                TreeControl.Node parent, before;
+                Point clientPoint = TreeControl.PointToClient(new Point(e.X, e.Y));
+                if (TreeControl.GetInsertionNodes(clientPoint, out parent, out before))
+                {
+                    canInsert = ApplicationUtil.CanInsertBetween(
+                        m_treeControlAdapter.TreeView,
+                        parent.Tag,
+                        before != null ? before.Tag : null,
+                        e.Data);
+                }
+            }
+            else
+            {
+                canInsert = ApplicationUtil.CanInsert(
+                    m_treeControlAdapter.TreeView,
+                    m_treeControlAdapter.LastHit,
+                    e.Data);
+            }
 
-            bool canInsert = ApplicationUtil.CanInsert(
-                m_treeControlAdapter.TreeView,
-                m_treeControlAdapter.LastHit,
-                e.Data);
             e.Effect = canInsert ? DragDropEffects.Move : DragDropEffects.None;
 
-            if (showDragBetweenCue != TreeControl.ShowDragBetweenCue)
-                TreeControl.Refresh();
+            // A refresh is required to display the drag-between cue.
+            if (TreeControl.ShowDragBetweenCue)
+                TreeControl.Invalidate();
         }
 
         /// <summary>
@@ -174,17 +191,34 @@ namespace Sce.Atf.Applications
         /// <param name="e">Event args from the tree control's DragDrop event</param>
         protected virtual void OnDragDrop(DragEventArgs e)
         {
-            ApplicationUtil.Insert(
-                m_treeControlAdapter.TreeView, 
-                m_treeControlAdapter.LastHit, 
-                e.Data, 
-                "Drag and Drop", 
-                m_statusService);
+            if (TreeControl.DragBetween)
+            {
+                TreeControl.Node parent, before;
+                Point clientPoint = TreeControl.PointToClient(new Point(e.X, e.Y));
+                if (TreeControl.GetInsertionNodes(clientPoint, out parent, out before))
+                {
+                    ApplicationUtil.InsertBetween(
+                        m_treeControlAdapter.TreeView,
+                        parent.Tag,
+                        before != null ? before.Tag : null,
+                        e.Data,
+                        "Drag and Drop",
+                        m_statusService);
+                }
+            }
+            else
+            {
+                ApplicationUtil.Insert(
+                    m_treeControlAdapter.TreeView,
+                    m_treeControlAdapter.LastHit,
+                    e.Data,
+                    "Drag and Drop",
+                    m_statusService);
+            }
 
             if (!TreeControl.ShowDragBetweenCue)
                 return;
 
-            TreeControl.ShowDragBetweenCue = false;
             TreeControl.Invalidate();
         }
 

--- a/Framework/Atf.Gui.WinForms/Applications/SettingsDialog.cs
+++ b/Framework/Atf.Gui.WinForms/Applications/SettingsDialog.cs
@@ -52,10 +52,10 @@ namespace Sce.Atf.Applications
             propertiesPanel.Controls.Add(m_propertyGrid);
 
             // select an initial node so something is displayed in the PropertyGrid
-            TreeControl.Node firstNode;
+            TreeControl.Node firstNode = null;
             if (pathName != null)
                 firstNode = m_treeControlAdapter.ExpandPath(m_settingsService.GetSettingsPath(pathName));
-            else
+            if (firstNode == null) // in case pathName is not null, but ExpandPath returns null
                 firstNode = m_treeControl.ExpandToFirstLeaf();
 
             firstNode.Selected = true;

--- a/Framework/Atf.Gui.WinForms/Applications/SettingsService.cs
+++ b/Framework/Atf.Gui.WinForms/Applications/SettingsService.cs
@@ -638,22 +638,22 @@ namespace Sce.Atf.Applications
 
             // first node is the settings tree root
             Tree<object> node = m_userSettings;
-            path[0] = m_userSettings.Value;
+            path[0] = m_userSettings;
 
             // middle nodes are folders
             for (int i = 1; i < path.Length - 1; i++)
             {
                 node = GetOrCreateFolder(pathSegments[i - 1], node);
-                path[i] = node.Value;
+                path[i] = node;
             }
 
             // leaf node is user settings object
             foreach (Tree<object> leaf in node.Children)
             {
-                var info = node.Value as UserSettingsInfo;
+                UserSettingsInfo info = leaf.Value as UserSettingsInfo;
                 if (info != null && info.Name == pathSegments[pathSegments.Length - 1])
                 {
-                    path[path.Length - 1] = leaf.Value;
+                    path[path.Length - 1] = leaf;
                     break;
                 }
             }

--- a/Framework/Atf.Gui/Applications/IOrderedInsertionContext.cs
+++ b/Framework/Atf.Gui/Applications/IOrderedInsertionContext.cs
@@ -1,0 +1,36 @@
+﻿// See License.txt.
+
+namespace Sce.Atf.Applications
+{
+    /// <summary>
+    /// Interface for contexts that can insert new objects (e.g., via drag and drop) into a
+    /// particular order relative to other objects. Works with both hierarchical and non-
+    /// hierarchical data views.</summary>
+    /// <remarks>Normally implemented along with IInstancingContext. Used by TreeControlEditor,
+    /// for example, to allow specific tree editors like the ProjectLister to let the user
+    /// reorder items in a list.</remarks>
+    public interface IOrderedInsertionContext
+    {
+        /// <summary>
+        /// Returns true if 'item' can be inserted.</summary>
+        /// <param name="parent">The object that will become the parent of the inserted object.
+        /// Can be null if the list of objects is a flat list or if the root should be replaced.</param>
+        /// <param name="before">The object that is immediately before the inserted object.
+        /// Can be null to indicate that the inserted item should become the first child.</param>
+        /// <param name="item">The item to be inserted. Consider using Util.ConvertData(item, false)
+        /// to retrieve the final one or more items to be inserted.</param>
+        /// <returns>True iff 'item' can be successfully inserted</returns>
+        bool CanInsert(object parent, object before, object item);
+
+        /// <summary>
+        /// Inserts 'item' into the set of objects at the desired position. Can only be called
+        /// if CanInsert() returns true.</summary>
+        /// <param name="parent">The object that will become the parent of the inserted object.
+        /// Can be null if the list of objects is a flat list or if the root should be replaced.</param>
+        /// <param name="before">The object that is immediately before the inserted object.
+        /// Can be null to indicate that the inserted item should become the first child.</param>
+        /// <param name="item">The item to be inserted. Consider using Util.ConvertData(item, false)
+        /// to retrieve the final one or more items to be inserted.</param>
+        void Insert(object parent, object before, object item);
+    }
+}

--- a/Framework/Atf.Gui/Atf.Gui.vs2010.csproj
+++ b/Framework/Atf.Gui/Atf.Gui.vs2010.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Applications\IHelpContext.cs" />
     <Compile Include="Applications\ILastHitAware.cs" />
     <Compile Include="Applications\IMessageBoxService.cs" />
+    <Compile Include="Applications\IOrderedInsertionContext.cs" />
     <Compile Include="Applications\IOscService.cs" />
     <Compile Include="Applications\IPinnable.cs" />
     <Compile Include="Applications\ISelectionPathProvider.cs" />


### PR DESCRIPTION
If a TreeControl’s ShowDragBetweenCue is set to true, and if the
context can be adapted to the new interface, IOrderedInsertionContext,
then the user will be allowed to re-order nodes by dragging. Also,
objects can be dragged into a specific location within a tree, like
when dragging from the palette.