### PR TITLE
use null-conditional operator when accessing dockContent.Pane

### DIFF
--- a/Framework/Atf.Gui.WinForms/Applications/ControlHostService.cs
+++ b/Framework/Atf.Gui.WinForms/Applications/ControlHostService.cs
@@ -829,7 +829,7 @@ namespace Sce.Atf.Applications
 
         private DockPaneStripBase GetDockPaneStripBase(DockContent dockContent)
         {
-            DockPane dockPane = dockContent.Pane;
+            DockPane dockPane = dockContent?.Pane;
             if (dockPane != null)
             {
                 foreach (Control c in dockPane.Controls)


### PR DESCRIPTION
tiny fix - been getting an intermittent crash in LevelEditor on quit, sometimes this gets called with a null argument