### PR TITLE
bugfix: erroneously-lengthed color value

### DIFF
--- a/Framework/Atf.Gui.WinForms/Applications/SkinService/Skin.tmpl
+++ b/Framework/Atf.Gui.WinForms/Applications/SkinService/Skin.tmpl
@@ -27,10 +27,10 @@
 
         <setter propertyName="CaptionButtonHoverColor">
             <valueInfo type="System.Drawing.Color" value="#FF46464B"/>
-        </setter>        
-    </style>    
+        </setter>
+    </style>
     <style name="ControlStyle" targetType="System.Windows.Forms.Control">
-        
+
         <setter propertyName="BackColor">
             <valueInfo type="System.Drawing.Color" value="#FF333333"/>
         </setter>
@@ -44,7 +44,7 @@
                 <constructorParams>
                     <valueInfo type="string" value="Verdana"/>
                     <valueInfo type="float" value="9.0"/>
-                    <valueInfo type="System.Drawing.FontStyle" value="Regular"/>                    
+                    <valueInfo type="System.Drawing.FontStyle" value="Regular"/>
                 </constructorParams>
             </valueInfo>
         </setter>
@@ -58,12 +58,12 @@
             <valueInfo type="System.Windows.Forms.FlatStyle" value="Flat"/>
         </setter>
 
-    </style>    
+    </style>
     <style name="GroupBoxStyle" targetType="System.Windows.Forms.GroupBox">
         <setter propertyName="BackColor">
             <valueInfo type="System.Drawing.Color" value="#00000000"/>
         </setter>
-    </style>    
+    </style>
     <style name="LabelStyle" targetType="System.Windows.Forms.Label">
         <setter propertyName="BackColor">
             <valueInfo type="System.Drawing.Color" value="#00000000"/>
@@ -80,18 +80,18 @@
         </setter>
         <setter propertyName="FlatStyle">
             <valueInfo type="System.Windows.Forms.FlatStyle" value="Flat"/>
-        </setter>        
-    </style>    
+        </setter>
+    </style>
     <style name="CheckBoxStyle" targetType="System.Windows.Forms.CheckBox">
         <setter propertyName="FlatStyle">
             <valueInfo type="System.Windows.Forms.FlatStyle" value="Flat"/>
         </setter>
-    </style>    
+    </style>
     <style name="SplitContainerStyle" targetType="System.Windows.Forms.SplitContainer">
         <setter propertyName="BackColor">
             <valueInfo type="System.Drawing.Color" value="#FF484848"/>
         </setter>
-    </style>       
+    </style>
     <style name="DockStyle" targetType="Sce.Atf.Applications.ControlHostService+DockPanel">
 
         <setter propertyName="DockBackColor">
@@ -273,7 +273,7 @@
 
             </valueInfo>
         </setter>
-    </style>   
+    </style>
     <style name="PropertyGridDescriptionControlStyle" targetType="Sce.Atf.Controls.PropertyEditing.PropertyGrid+DescriptionControl">
         <setter propertyName="BackColor">
             <valueInfo type="System.Drawing.Color" value="#FF333333"/>
@@ -285,7 +285,7 @@
                 </constructorParams>
             </valueInfo>
         </setter>
-    </style>    
+    </style>
     <style name="PropertyGridViewStyle" targetType="Sce.Atf.Controls.PropertyEditing.PropertyGridView">
 
         <setter propertyName="PropertyBackgroundBrush">
@@ -361,11 +361,11 @@
             </valueInfo>
         </setter>
 
-    </style>    
+    </style>
     <style name="TreeStyle" targetType="Sce.Atf.Controls.TreeControl">
         <setter propertyName="ItemRenderer">
             <valueInfo type="Sce.Atf.Controls.TreeItemRenderer">
-              
+
                 <setter propertyName="TextBrush">
                     <valueInfo type="System.Drawing.SolidBrush">
                         <constructorParams>
@@ -397,7 +397,7 @@
                   </constructorParams>
                 </valueInfo>
               </setter>
-              
+
               <setter propertyName="MatchedHighlightBrush">
                 <valueInfo type="System.Drawing.SolidBrush">
                   <constructorParams>
@@ -405,7 +405,7 @@
                   </constructorParams>
                 </valueInfo>
               </setter>
-              
+
               <setter propertyName="NoMatchHighlightBrush">
                 <valueInfo type="System.Drawing.SolidBrush">
                   <constructorParams>
@@ -413,7 +413,7 @@
                   </constructorParams>
                 </valueInfo>
               </setter>
-             
+
                 <setter propertyName="DeactiveHighlightBrush">
                     <valueInfo type="System.Drawing.SolidBrush">
                         <constructorParams>
@@ -572,7 +572,7 @@
                             <valueInfo type="System.Drawing.Color" value="#FF777777"/>
                         </setter>
                         <setter propertyName="SettableMenuItemPressedGradientEnd">
-                            <valueInfo type="System.Drawing.Color" value="#FFFF777777"/>
+                            <valueInfo type="System.Drawing.Color" value="#FF777777"/>
                         </setter>
                         <setter propertyName="SettableRaftingContainerGradientBegin">
                             <valueInfo type="System.Drawing.Color" value="#FFF0F0F0"/>
@@ -727,7 +727,7 @@
                         <valueInfo type="System.Drawing.Color" value="#FF50F057"/>
                     </constructorParams>
                 </valueInfo>
-                
+
                 <valueInfo type="Sce.Atf.Controls.SyntaxEditorControl.TextHighlightStyle">
                     <constructorParams>
                         <valueInfo type="string" value="StringDelimiterStyle"/>


### PR DESCRIPTION
I found that I couldn't create a new skin in the Skin Editor without having my application crash; this is because one of the color hex codes in the embedded skin template resource was one byte too long.