### PR TITLE
minor improvements for FlagsUITypeEditor and FlagsTypeConverter

### DIFF
--- a/Framework/Atf.Gui.WinForms/Controls/PropertyEditing/FlagsUITypeEditor.cs
+++ b/Framework/Atf.Gui.WinForms/Controls/PropertyEditing/FlagsUITypeEditor.cs
@@ -120,7 +120,7 @@ namespace Sce.Atf.Controls.PropertyEditing
 
                 if (value is string)
                     FillCheckedListBoxFromString(value, checkedListBox);
-                else if (value is int)
+                else if (value is int || value is uint)
                     FillCheckedListBoxFromInt(value, checkedListBox);
                 // otherwise, ignore value
 

--- a/Framework/Atf.Gui.WinForms/Controls/PropertyEditing/FlagsUITypeEditor.cs
+++ b/Framework/Atf.Gui.WinForms/Controls/PropertyEditing/FlagsUITypeEditor.cs
@@ -183,7 +183,10 @@ namespace Sce.Atf.Controls.PropertyEditing
 
         private void FillCheckedListBoxFromInt(object value, CheckedListBox listBox)
         {
-            int flags = (int)value;
+            if (!(value is int || value is uint))
+                throw new ArgumentException("value must be int or uint");
+
+            int flags = Convert.ToInt32(value);
             for (int i = 0; i < m_values.Length; ++i)
             {
                 bool isChecked = (flags & m_values[i]) == m_values[i];

--- a/Framework/Atf.Gui/Controls/PropertyEditing/FlagsTypeConverter.cs
+++ b/Framework/Atf.Gui/Controls/PropertyEditing/FlagsTypeConverter.cs
@@ -83,16 +83,35 @@ namespace Sce.Atf.Controls.PropertyEditing
             if (flagString != null)
             {
                 string internalNames = string.Empty;
-                string[] displayNames = flagString.Split('|');
-                foreach (string displayName in displayNames)
+
+                // Support the case when users type a value like "6" to mean 4 | 2.
+                int intvalue = 0;
+                if (Int32.TryParse(flagString, out intvalue))
                 {
-                    string name = GetInternalName(displayName);
-                    if (name != null)
+                    for (int idx = 0; idx < m_values.Length; idx++)
                     {
-                        if (internalNames != string.Empty)
-                            internalNames += '|' + name;
-                        else
-                            internalNames = name;
+                        if ((intvalue & m_values[idx]) == m_values[idx])
+                        {
+                            if (internalNames != string.Empty)
+                                internalNames += '|' + m_displayNames[idx];
+                            else
+                                internalNames = m_displayNames[idx];
+                        }
+                    }
+                }
+                else
+                {
+                    string[] displayNames = flagString.Split('|');
+                    foreach (string displayName in displayNames)
+                    {
+                        string name = GetInternalName(displayName);
+                        if (name != null)
+                        {
+                            if (internalNames != string.Empty)
+                                internalNames += '|' + name;
+                            else
+                                internalNames = name;
+                        }
                     }
                 }
                 // Returning the given value allows for editing the enum as long as the DomValueValidator also


### PR DESCRIPTION
As per topic, some minor fixes / improvements for flags handling. I've provided them as separate commits for clarity and ease of selective merging if some of what I'm doing here doesn't pass muster. :)

- [3107b8c](https://github.com/SonyWWS/ATF/commit/3107b8cd4301e6b284a8db8a65d10f08dedd5db4): `FlagsUITypeEditor` can be set up on a property of type `uint` but when used that way, the checked list box isn't populated properly from the underlying value
- [5033c64](https://github.com/SonyWWS/ATF/commit/5033c64a797464f85cc01a8337f05d30eda16ab4): throw an exception when an object that isn't int or uint is passed in
- [dbd06d5](https://github.com/SonyWWS/ATF/commit/dbd06d5977014b17d94e5bb1314b7e40a73b9884): `FlagsTypeConverter` has a `ConvertFrom` function that parses enum literals into their underlying values. It feels like it'd be good to support integer literals here too - just type 6 for 4 | 2, etc

Thanks for making this open source, by the way! It's been hugely helpful for my team.