### PR TITLE
NumericTupleControl resize fix

### DIFF
--- a/Framework/Atf.Gui.WinForms/Controls/NumericTupleControl.cs
+++ b/Framework/Atf.Gui.WinForms/Controls/NumericTupleControl.cs
@@ -250,7 +250,14 @@ namespace Sce.Atf.Controls
                 }
             }
             ResumeLayout(true);
-            base.OnResize(e);          
+
+            // Invalidate the Control to ensure that 1) OnPaint() gets called below so that
+            //  the labels get placed correctly and 2) the PaintEventArgs.ClipRectangle is as
+            //  large as it needs to be. Without Invalidate(), the ClipRectangle could be very
+            //  small or the paint event may not even happen at all.
+            Invalidate();
+
+            base.OnResize(e);
         }
 
         /// <summary>


### PR DESCRIPTION
Resizing this Control was not always causing the Control to be repainted.

If you use the DomPropertyEditor sample app and scroll down until you see one of the NumericTupleEditors, and resize the Property Editor, you'll see refresh problems with the NumericTupleControl. Sometimes the labels and child text boxes would never get repainted.